### PR TITLE
fcoe-utils: Fix get_ctlr_num() for large ctlr_* indices

### DIFF
--- a/lib/sysfs_hba.c
+++ b/lib/sysfs_hba.c
@@ -606,7 +606,7 @@ static int get_ctlr_num(const char *netdev)
 		if (!ctlr)
 			continue;
 
-		ctlr_num = atoi(&ctlr[strlen(ctlr) - 1]);
+		ctlr_num = atoi(&ctlr[sizeof("ctlr_") - 1]);
 		break;
 	}
 


### PR DESCRIPTION
I sent this patch (but with prefix "fcoeadm:" in commit message) to fcoe-devel@, but still waiting a response. 