### PR TITLE
fcoemon: Correctly handle options in the service file

### DIFF
--- a/doc/fcoemon.txt
+++ b/doc/fcoemon.txt
@@ -53,13 +53,13 @@ OPTIONS
 -------
 *-f*, *--foreground*::
 	Run *fcoemon* in the foreground.
-*-d*, *--debug*::
-	Enable debugging messages.
+*-d*, *--debug=yes|no*::
+	Enable or disable debugging messages.
 *-l*, *--legacy*::
 	Force fcoemon to use the legacy /sys/module/libfcoe/parameters/
 	interface. The default is to use the newer /sys/bus/fcoe/ interfaces
 	if they are available.
-*-s*, *--syslog*::
+*-s*, *--syslog=yes|no*::
 	Use syslogd for logging. The default behavior is to log to stdout
 	and stderr.
 *-h*, *--help*::

--- a/etc/systemd/fcoe.service
+++ b/etc/systemd/fcoe.service
@@ -4,9 +4,9 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-EnvironmentFile=/etc/sysconfig/fcoe
+EnvironmentFile=/etc/fcoe/config
 ExecStartPre=/sbin/modprobe -qa $SUPPORTED_DRIVERS
-ExecStart=/usr/sbin/fcoemon $FCOEMON_OPTS
+ExecStart=/usr/sbin/fcoemon --debug=$DEBUG --syslog=$SYSLOG
 
 [Install]
 WantedBy=multi-user.target

--- a/fcoemon.c
+++ b/fcoemon.c
@@ -335,9 +335,9 @@ static int fcoe_vid_from_ifname(const char *ifname);
  * Table for getopt_long(3).
  */
 static struct option fcm_options[] = {
-	{"debug", 0, NULL, 'd'},
+	{"debug", 1, NULL, 'd'},
 	{"legacy", 0, NULL, 'l'},
-	{"syslog", 0, NULL, 's'},
+	{"syslog", 1, NULL, 's'},
 	{"exec", 1, NULL, 'e'},
 	{"foreground", 0, NULL, 'f'},
 	{"version", 0, NULL, 'v'},
@@ -3235,9 +3235,9 @@ static void fcm_usage(void)
 {
 	printf("Usage: %s\n"
 	       "\t [-f|--foreground]\n"
-	       "\t [-d|--debug]\n"
+	       "\t [-d|--debug=yes|no]\n"
 	       "\t [-l|--legacy]\n"
-	       "\t [-s|--syslog]\n"
+	       "\t [-s|--syslog=yes|no]\n"
 	       "\t [-v|--version]\n"
 	       "\t [-h|--help]\n\n", progname);
 	exit(1);
@@ -3691,22 +3691,28 @@ int main(int argc, char **argv)
 	sa_log_flags = 0;
 	openlog(sa_log_prefix, LOG_CONS, LOG_DAEMON);
 
-	while ((c = getopt_long(argc, argv, "fdhlsv",
+	while ((c = getopt_long(argc, argv, "fd:hls:v",
 				fcm_options, NULL)) != -1) {
 		switch (c) {
 		case 'f':
 			fcm_fg = 1;
 			break;
 		case 'd':
-			fcoe_config.debug = 1;
-			enable_debug_log(1);
+			if (!strncmp(optarg, "yes", 3) ||
+			    !strncmp(optarg, "YES", 3)) {
+				fcoe_config.debug = 1;
+				enable_debug_log(1);
+			}
 			break;
 		case 'l':
 			force_legacy = true;
 			break;
 		case 's':
-			fcoe_config.use_syslog = 1;
-			enable_syslog(1);
+			if (!strncmp(optarg, "yes", 3) ||
+			    !strncmp(optarg, "YES", 3)) {
+				fcoe_config.use_syslog = 1;
+				enable_syslog(1);
+			}
 			break;
 		case 'v':
 			printf("%s\n", FCOE_UTILS_VERSION);


### PR DESCRIPTION
When runnig under systemd we can't really modify the arguments
to provide an 'FCOEMON_OPTS' variable. Instead we should be
modifying fcoemon --debug and --syslog to accept 'yes' or 'no'
as parameters; that way we can use the variables directly.

Signed-off-by: Hannes Reinecke <hare@suse.de>