### PR TITLE
In one of the scenarios it was noticed that when the fcoemon command is

### DIFF
--- a/doc/fcoemon.8
+++ b/doc/fcoemon.8
@@ -29,7 +29,7 @@
 fcoemon \- Open\-FCoE service daemon
 .SH "SYNOPSIS"
 .sp
-\fBfcoemon\fR [\-f|\-\-foreground] [\-l|\-\-legacy] [\-d|\-\-debug] [\-s|\-\-syslog]
+\fBfcoemon\fR [\-f|\-\-foreground] [\-l|\-\-legacy] [\-d|\-\-debug] [\-e|\-\-start] [\-s|\-\-syslog]
 .sp
 \fBfcoemon\fR \-h|\-\-help
 .sp
@@ -57,6 +57,11 @@ in the foreground\&.
 \fB\-d\fR, \fB\-\-debug\fR
 .RS 4
 Enable debugging messages\&.
+.RE
+.PP
+\fB\-e\fR, \fB\-\-start\fR
+.RS 4
+Start fcoemon daemon/service manually\&.
 .RE
 .PP
 \fB\-l\fR, \fB\-\-legacy\fR

--- a/doc/fcoemon.txt
+++ b/doc/fcoemon.txt
@@ -19,7 +19,7 @@ fcoemon - Open-FCoE service daemon
 
 SYNOPSIS
 --------
-*fcoemon* [-f|--foreground] [-l|--legacy] [-d|--debug] [-s|--syslog]
+*fcoemon* [-f|--foreground] [-l|--legacy] [-d|--debug] [-e|--start] [-s|--syslog]
 
 *fcoemon* -h|--help
 
@@ -55,6 +55,8 @@ OPTIONS
 	Run *fcoemon* in the foreground.
 *-d*, *--debug=yes|no*::
 	Enable or disable debugging messages.
+*-e*, *--start*::
+	Start fcoemon daemon/service manually.
 *-l*, *--legacy*::
 	Force fcoemon to use the legacy /sys/module/libfcoe/parameters/
 	interface. The default is to use the newer /sys/bus/fcoe/ interfaces
@@ -168,7 +170,7 @@ of the *fcoe* service.
 /etc/sysconfig/fcoe
 ~~~~~~~~~~~~~~~~~~~
 On systemd-enabled systems, this is the primary configuration file used for
-the *fcoe* system service. Add *--debug* to *FCOEMON_OPTS* to enable debug 
+the *fcoe* system service. Add *--debug* to *FCOEMON_OPTS* to enable debug
 log messages. Any changes to this file will require a restart of the *fcoe*
 service.
 

--- a/fcoemon.c
+++ b/fcoemon.c
@@ -338,7 +338,7 @@ static struct option fcm_options[] = {
 	{"debug", 1, NULL, 'd'},
 	{"legacy", 0, NULL, 'l'},
 	{"syslog", 1, NULL, 's'},
-	{"exec", 1, NULL, 'e'},
+	{"exec", 0, NULL, 'e'},
 	{"foreground", 0, NULL, 'f'},
 	{"version", 0, NULL, 'v'},
 	{NULL, 0, NULL, 0}
@@ -3243,6 +3243,7 @@ static void fcm_usage(void)
 	printf("Usage: %s\n"
 	       "\t [-f|--foreground]\n"
 	       "\t [-d|--debug=yes|no]\n"
+				 "\t [-e]--start\n"
 	       "\t [-l|--legacy]\n"
 	       "\t [-s|--syslog=yes|no]\n"
 	       "\t [-v|--version]\n"
@@ -3698,7 +3699,7 @@ int main(int argc, char **argv)
 	sa_log_flags = 0;
 	openlog(sa_log_prefix, LOG_CONS, LOG_DAEMON);
 
-	while ((c = getopt_long(argc, argv, "fd:hls:v",
+	while ((c = getopt_long(argc, argv, "fd:ehls:v",
 				fcm_options, NULL)) != -1) {
 		switch (c) {
 		case 'f':
@@ -3710,6 +3711,8 @@ int main(int argc, char **argv)
 				fcoe_config.debug = 1;
 				enable_debug_log(1);
 			}
+			break;
+		case 'e':
 			break;
 		case 'l':
 			force_legacy = true;
@@ -3730,7 +3733,7 @@ int main(int argc, char **argv)
 		break;
 		}
 	}
-	if (argc != optind)
+	if (argc != optind || argc == 1)
 		fcm_usage();
 
 	umask(0);


### PR DESCRIPTION
run without any arguments, all the fcoe interfaces would go down and
access to LUNs would get lost. In this case, there was 4 port FCoE HBA
used with the two ports in bonding configuration. This issue is not
easily reproducible. This patch would print usage() information when
fcoemon command is run without any arguments. In order to run the
fcoemon daemon manually, with this patch, we could use `fcoemon -e`.

Signed-off-by: Nitin U. Yewale <nyewale@redhat.com>