### PR TITLE
Exit fcoemon command if daemon is already running.

### DIFF
--- a/fcoemon.c
+++ b/fcoemon.c
@@ -3796,8 +3796,10 @@ int main(int argc, char **argv)
 		fcm_dcbd_init();
 
 	rc = fcm_srv_create(&srv_info);
-	if (rc != 0)
-		goto err_cleanup;
+	if (rc != 0) {
+		FCM_LOG_DBG("Daemon already running OR Failed to create socket so exiting!\n");
+		exit(1);
+	}
 
 	if (!fcm_fg && daemon(0, !fcoe_config.use_syslog)) {
 		FCM_LOG("Starting daemon failed");


### PR DESCRIPTION
If fcoemon daemon is running and when we run `fcoemon` with or without ` -d` the command, command exits with the message 

# fcoemon 
fcoemon: error 98 Address already in use
fcoemon: Failed to bind socket

However, if the interface config file names are matching with the interface names, the interfaces are destroyed and the connectivity to the storage is lost.
(This seems to be occurring when no VLAN is used.)

Mentioned patch fixes this by _EXITING_ the `fcoemon` command without destroying the interfaces.

P.S please add

Signed-off-by: Laurence Oberman <loberman@redhat.com>
Suggested by : Grigory Trenin


