### PR TITLE
Exit fcoemon command if fcoemon daemon is already running.

### DIFF
--- a/fcoemon.c
+++ b/fcoemon.c
@@ -3796,8 +3796,14 @@ int main(int argc, char **argv)
 		fcm_dcbd_init();
 
 	rc = fcm_srv_create(&srv_info);
-	if (rc != 0)
-		goto err_cleanup;
+	if (rc != 0) {
+		if (rc == EADDRINUSE) {
+			FCM_LOG_DBG("Daemon already running OR Failed to bind socket so exiting!\n");
+			exit(1);
+		}
+		else
+			goto err_cleanup;
+	}
 
 	if (!fcm_fg && daemon(0, !fcoe_config.use_syslog)) {
 		FCM_LOG("Starting daemon failed");


### PR DESCRIPTION
Made the changes accordingly. I was able to test the if loop where `fcoemon` command exists if the `fcoe` daemon is already running.

Please add
Signed-off-by: Laurence Oberman loberman@redhat.com
Suggested by : Grigory Trenin