### PR TITLE
Fix GCC 12 warning.

### DIFF
--- a/fcoeadm_display.c
+++ b/fcoeadm_display.c
@@ -246,7 +246,7 @@ static void show_full_lun_info(unsigned int hba, unsigned int port,
 	char vendor[256];
 	char model[256];
 	char rev[256];
-	char *osname;
+	char *osname = NULL;
 	char *capstr;
 	uint64_t lba = 0;
 	uint32_t blksize = 0;


### PR DESCRIPTION
Fixes:
```
    inlined from ‘show_full_lun_info’ at fcoeadm_display.c:310:2:
/usr/include/bits/stdio2.h:112:10: error: ‘osname’ may be used uninitialized [-Werror=maybe-uninitialized]
  112 |   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
fcoeadm_display.c: In function ‘show_full_lun_info’:
fcoeadm_display.c:249:15: note: ‘osname’ was declared here
  249 |         char *osname;
      |               ^~~~~~
```