### PR TITLE
more GCC 12 build issues with snprintf truncation in fcoemon

### DIFF
--- a/fcoemon.c
+++ b/fcoemon.c
@@ -3135,55 +3135,55 @@ static void fcm_netif_advance(struct fcm_netif *ff)
 	case FCD_ERROR:
 		break;
 	case FCD_GET_DCB_STATE:
-		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%s",
+		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%.*s",
 			 DCB_CMD, CLIF_RSP_VERSION,
 			 CMD_GET_CONFIG, FEATURE_DCB, 0,
-			 (u_int) strlen(ff->ifname), ff->ifname);
+			 (u_int) strlen(ff->ifname), IFNAMSIZ, ff->ifname);
 		ff->response_pending = fcm_dcbd_request(buf);
 		break;
 	case FCD_SEND_CONF:
 		snprintf(params, sizeof(params), "%x1%x02",
 			 ff->ff_app_info.enable,
 			 ff->ff_app_info.willing);
-		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%s%s",
+		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%.*s%s",
 			 DCB_CMD, CLIF_RSP_VERSION,
 			 CMD_SET_CONFIG, FEATURE_APP, APP_FCOE_STYPE,
-			 (u_int) strlen(ff->ifname), ff->ifname, params);
+			 (u_int) strlen(ff->ifname), IFNAMSIZ, ff->ifname, params);
 		ff->response_pending = fcm_dcbd_request(buf);
 		break;
 	case FCD_GET_PFC_CONFIG:
-		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%s%s",
+		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%.*s%s",
 			 DCB_CMD, CLIF_RSP_VERSION,
 			 CMD_GET_CONFIG, FEATURE_PFC, 0,
-			 (u_int) strlen(ff->ifname), ff->ifname, "");
+			 (u_int) strlen(ff->ifname), IFNAMSIZ, ff->ifname, "");
 		ff->response_pending = fcm_dcbd_request(buf);
 		break;
 	case FCD_GET_APP_CONFIG:
-		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%s%s",
+		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%.*s%s",
 			 DCB_CMD, CLIF_RSP_VERSION,
 			 CMD_GET_CONFIG, FEATURE_APP, APP_FCOE_STYPE,
-			 (u_int) strlen(ff->ifname), ff->ifname, "");
+			 (u_int) strlen(ff->ifname), IFNAMSIZ, ff->ifname, "");
 		ff->response_pending = fcm_dcbd_request(buf);
 		break;
 	case FCD_GET_PFC_OPER:
-		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%s%s",
+		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%.*s%s",
 			 DCB_CMD, CLIF_RSP_VERSION,
 			 CMD_GET_OPER, FEATURE_PFC, 0,
-			 (u_int) strlen(ff->ifname), ff->ifname, "");
+			 (u_int) strlen(ff->ifname), IFNAMSIZ, ff->ifname, "");
 		ff->response_pending = fcm_dcbd_request(buf);
 		break;
 	case FCD_GET_APP_OPER:
-		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%s%s",
+		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%.*s%s",
 			 DCB_CMD, CLIF_RSP_VERSION,
 			 CMD_GET_OPER, FEATURE_APP, APP_FCOE_STYPE,
-			 (u_int) strlen(ff->ifname), ff->ifname, "");
+			 (u_int) strlen(ff->ifname), IFNAMSIZ, ff->ifname, "");
 		ff->response_pending = fcm_dcbd_request(buf);
 		break;
 	case FCD_GET_PEER:
-		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%s%s",
+		snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%.*s%s",
 			 DCB_CMD, CLIF_RSP_VERSION,
 			 CMD_GET_PEER, FEATURE_APP, APP_FCOE_STYPE,
-			 (u_int) strlen(ff->ifname), ff->ifname, "");
+			 (u_int) strlen(ff->ifname), IFNAMSIZ, ff->ifname, "");
 		ff->response_pending = fcm_dcbd_request(buf);
 		break;
 	case FCD_DONE:


### PR DESCRIPTION
I'm still seeing gcc 12 build failures in the Fedora build system after the fix in #22, but only on 32-bit archs (armv7hl and i686).  I don't have a good answer as to why these format truncation warnings only trigger on 32-bit.

The issues are all potential snprintf truncations in fcoemon.c:fcm_netif_advance()
```
fcoemon.c: In function 'fcm_netif_advance.part.0':
fcoemon.c:3183:69: error: '%s' directive output may be truncated writing up to 2147483644 bytes into a region of size between 64 and 70 [-Werror=format-truncation=]
 3183 |                 snprintf(buf, sizeof(buf), "%c%x%2.2x%2.2x%2.2x%2.2x%s%s",
      |                                                                     ^~
In file included from /usr/include/stdio.h:894,
                 from /usr/include/malloc.h:25,
                 from fcoemon.c:24:
In function 'snprintf',
    inlined from 'fcm_netif_advance.part.0' at fcoemon.c:3183:3:
/usr/include/bits/stdio2.h:71:10: note: '__snprintf_chk' output between 11 and 2147483661 bytes into a destination of size 80
   71 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   73 |                                    __va_arg_pack ());
      | 
```

I looked at detecting the truncation, but without extensive error handling additions that looks like a worse choice to just silence the warnings.

fcm_netif.ifname is an IFNAMSIZ array, but formating with %s doesn't understand that, so add a precision modifier every time we print it to limit the output.  This allows the compiler to verify that the output buffer is of sufficient length to never truncate.