### PR TITLE
Don't attempt to memcpy() zero bytes

### DIFF
--- a/lib/rtnetlink.c
+++ b/lib/rtnetlink.c
@@ -172,7 +172,8 @@ static void add_rtattr(struct nlmsghdr *n, int type, const void *data, int alen)
 
 	rta->rta_type = type;
 	rta->rta_len = len;
-	memcpy(RTA_DATA(rta), data, alen);
+	if (alen > 0)
+		memcpy(RTA_DATA(rta), data, alen);
 	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
 }
 


### PR DESCRIPTION
`add_rtattr_nest()` is called in several places in the code. As part of its operation, it calls `add_rtattr(nm type, NULL, 0)` which results in `NULL` and 0 being passed to `memcpy()`. This fails with `-Werror=nonnull` on recent GCC.