### PR TITLE
Fix build against glibc 2.43

### DIFF
--- a/lib/fcoe_utils.c
+++ b/lib/fcoe_utils.c
@@ -161,7 +161,7 @@ int fcoe_checkdir(char *dir)
  */
 char *get_ifname_from_symbolic_name(const char *symbolic_name)
 {
-	char *last_space = strrchr(symbolic_name, ' ');
+	const char *last_space = strrchr(symbolic_name, ' ');
 
 	if (!last_space || strlen(last_space) == 1)
 		return NULL;

--- a/lib/sysfs_hba.c
+++ b/lib/sysfs_hba.c
@@ -441,7 +441,7 @@ char *get_pci_dev_from_netdev(const char *netdev)
 	free(path);
 	if (ret == -1) {
 		char realdev[256];
-		char *subif;
+		const char *subif;
 		size_t len;
 
 		subif = strchr(netdev, '.');


### PR DESCRIPTION
When strrchar gets a const char * to work on, it returns a pointer
into the same string; with glibc 2.43 it is being enforced to retain
the const attribute in this case
